### PR TITLE
Mautic 6 images

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,16 @@
 # Base Mautic image
 FROM mautic_upstream AS mautic_base_5
 
-# DXP variant
+# DXP variant for Mautic 5
 FROM mautic_base_5 AS mautic_dxp_5
 
 COPY 5/files/ /var/www/html/docroot/
+
+# Base Mautic 6 image
+FROM mautic_upstream AS mautic_base_6
+
+# DXP variant for Mautic 6
+FROM mautic_base_6 AS mautic_dxp_6
+
+# Note: When 6/files/ directory is created, uncomment the following line
+# COPY 6/files/ /var/www/html/docroot/

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -7,7 +7,7 @@ group "default" {
 }
 
 group "mautic-variants" {
-  targets = ["mautic-5", "mautic-5-dxp"]
+  targets = ["mautic-5", "mautic-5-dxp", "mautic-6", "mautic-6-dxp"]
 }
 
 target "common" {
@@ -48,5 +48,34 @@ target "mautic-5-dxp" {
     "${REPO_BASE}-dxp:5",
     "${REPO_BASE}-dxp:5.2",
     "${REPO_BASE}-dxp:5.2.5"
+  ]
+}
+
+#
+# MAUTIC 6
+#
+
+target "mautic-6" {
+  inherits = ["common"]
+  args = {
+  }
+  contexts = {
+    mautic_upstream = "docker-image://mautic/mautic:6.0.1-apache"
+  }
+  target = "mautic_base_6"
+  tags = [
+    "${REPO_BASE}:6",
+    "${REPO_BASE}:6.0",
+    "${REPO_BASE}:6.0.1"
+  ]
+}
+
+target "mautic-6-dxp" {
+  inherits = ["mautic-6"]
+  target = "mautic_dxp_6"
+  tags = [
+    "${REPO_BASE}-dxp:6",
+    "${REPO_BASE}-dxp:6.0",
+    "${REPO_BASE}-dxp:6.0.1"
   ]
 }


### PR DESCRIPTION
> [!NOTE]  
> Waiting for this https://github.com/mautic/docker-mautic/issues/340


This pull request introduces support for Mautic 6 in the Docker setup, including updates to the `Dockerfile` and `docker-bake.hcl` to define new base and DXP variants for Mautic 6. These changes ensure that the Docker configuration is prepared for the upcoming Mautic 6 release.

### Additions for Mautic 6 support:

* **`Dockerfile`**: Added new stages for `mautic_base_6` and `mautic_dxp_6` to define the base and DXP variants for Mautic 6. A placeholder for copying Mautic 6-specific files is also included but commented out for now.

* **`docker-bake.hcl`**:
  - Updated the `mautic-variants` group to include `mautic-6` and `mautic-6-dxp` targets.
  - Added new targets `mautic-6` and `mautic-6-dxp` with appropriate configurations, including inheritance, contexts, and tags for Docker images based on Mautic 6.Let's wait for the Mautic 6 Docker images to be released